### PR TITLE
Add shared header and footer

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css"
 import { Inter } from "next/font/google"
 import type { Metadata } from 'next'
 import ThemeProvider from "@/components/theme-provider";
+import SiteLayout from "@/components/layout/site-layout";
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -44,7 +45,9 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className={inter.className}>
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          <SiteLayout>{children}</SiteLayout>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import Link from 'next/link'
+
+export default function Footer() {
+  const year = new Date().getFullYear()
+  return (
+    <footer className="bg-zinc-900 text-white mt-8">
+      <div className="container mx-auto flex flex-col items-center px-4 py-6">
+        <nav className="space-x-4 text-sm mb-2">
+          <Link href="/blog" className="hover:underline">Blog</Link>
+          <Link href="/docs" className="hover:underline">Docs</Link>
+          <Link href="/release" className="hover:underline">Release</Link>
+        </nav>
+        <p className="text-xs text-zinc-400">&copy; {year} BoxLog</p>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import Link from 'next/link'
+
+export default function Header() {
+  return (
+    <header className="bg-zinc-900 text-white">
+      <div className="container mx-auto flex items-center justify-between px-4 py-4">
+        <Link href="/" className="text-lg font-bold">BoxLog</Link>
+        <nav className="space-x-4 text-sm">
+          <Link href="/blog" className="hover:underline">Blog</Link>
+          <Link href="/docs" className="hover:underline">Docs</Link>
+          <Link href="/release" className="hover:underline">Release</Link>
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/src/components/layout/site-layout.tsx
+++ b/src/components/layout/site-layout.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { usePathname } from 'next/navigation'
+import Header from './header'
+import Footer from './footer'
+
+export default function SiteLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const show = !pathname.startsWith('/app')
+  return (
+    <>
+      {show && <Header />}
+      {children}
+      {show && <Footer />}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add a site layout component with header and footer
- show navigation links to Blog, Docs and Release
- wrap all pages except `/app` with the new layout

## Testing
- `pnpm lint` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6859047c4260832eaac4f0656e7b2af5